### PR TITLE
Fixes for issue #20

### DIFF
--- a/src/classes/SmartFactory.cls
+++ b/src/classes/SmartFactory.cls
@@ -204,8 +204,9 @@ public with sharing class SmartFactory {
 
 				if (referenceObjectType == 'RecordType') {
 					setRecordType(obj);
-				} else if (cascade && referenceObjectType != obj.getSObjectType().getDescribe().getName()) {
-					// TODO avoid infinite loop for same-type references
+                } else if (cascade && referenceObjectType != obj.getSObjectType().getDescribe().getName() &&
+                            referenceObjectType !='BusinessHours') {
+                    // TODO avoid infinite loop for same-type references
 					System.debug('Creating reference to ' + referenceObjectType + ' for field ' + obj.getSObjectType().getDescribe().getName() + '.' + fieldDescribe.getName());
 					SObject reference = createSObject(referenceObjectType);
 					System.debug('Inserting ' + reference);


### PR DESCRIPTION
As discussed in #20 DML operations cannot be commited with BusinessHours object (see [here](http://salesforce.stackexchange.com/a/33659)). 

In the case we call SmartFactory to cascade create lookup objects and the object happen to have a lookup to BusinessHours, the system throws a DML exception. This patch avoids creating BusinessHours records for cascade creation.
